### PR TITLE
Add Brev launchable for PhysicsNeMo 26.05

### DIFF
--- a/brev/README.md
+++ b/brev/README.md
@@ -1,0 +1,52 @@
+# Brev launchable — End-to-End AI for Science
+
+This folder defines a [Brev](https://developer.nvidia.com/brev) launchable for the
+**End-to-End AI for Science** bootcamp. It builds on top of the official
+[NVIDIA PhysicsNeMo 26.05](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/physicsnemo/containers/physicsnemo?version=26.05)
+container and installs the additional dependencies the notebooks need via
+Docker Compose, then serves the bootcamp in JupyterLab.
+
+> The image is **built from the PhysicsNeMo base on the instance** — nothing is
+> pushed to or pulled from a private registry.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| [`docker-compose.yml`](docker-compose.yml) | Brev entrypoint. Builds `dockerfile`, requests all GPUs, exposes JupyterLab on `8888`. |
+| [`dockerfile`](dockerfile) | `FROM nvcr.io/nvidia/physicsnemo/physicsnemo:26.05`, installs system + Python deps, copies `workspace/`. |
+| [`requirements.txt`](requirements.txt) | Extra Python packages (JupyterLab, Earth2Studio, cartopy, mlflow, …). |
+| [`entrypoint.sh`](entrypoint.sh) | Launches JupyterLab serving `/workspace/python`. |
+
+## Prerequisites
+
+- A GPU instance with the NVIDIA Container Toolkit installed.
+- NGC access to pull the PhysicsNeMo base image
+  (`docker login nvcr.io` with an [NGC API key](https://docs.nvidia.com/ngc/ngc-catalog-user-guide/index.html#registering-activating-ngc-account)).
+
+## Run locally
+
+From the **repository root** (so the build context can see `workspace/`):
+
+```bash
+docker compose -f brev/docker-compose.yml up --build
+```
+
+Then open <http://localhost:8888> and start from `Start_Here.ipynb`.
+
+## Run on Brev
+
+Create a launchable pointing at this repository and select
+`brev/docker-compose.yml` as the compose file. Brev builds the image on the
+instance and forwards port `8888` for JupyterLab.
+
+## Notes
+
+- **Datasets are fetched on demand** rather than baked into the image. The
+  relevant notebooks/scripts download data when first run (see
+  `workspace/python/source_code/dataset.py`). This keeps the image small and
+  avoids flaky downloads during the build.
+- `earth2studio` is pinned to `0.14.0` to match the version used by the
+  in-repo GTC Earth-2 workshops. Module-specific extras (DoMINO, Transolver,
+  MagnetoHydrodynamics) can be installed from their own `requirements.txt`
+  inside a running notebook if needed.

--- a/brev/docker-compose.yml
+++ b/brev/docker-compose.yml
@@ -1,0 +1,37 @@
+name: end-to-end-ai-for-science
+
+# Brev launchable for the End-to-End AI for Science bootcamp.
+#
+# This builds the image locally from the official NVIDIA PhysicsNeMo 26.05
+# container (see brev/dockerfile) and installs the bootcamp dependencies.
+# No custom image is pulled or pushed - everything is built on the instance.
+#
+# Local usage:
+#   docker compose -f brev/docker-compose.yml up --build
+# then open http://localhost:8888
+
+services:
+  jupyter:
+    build:
+      # Build context is the repo root so the image can COPY workspace/.
+      context: ..
+      dockerfile: brev/dockerfile
+    image: end-to-end-ai-for-science:26.05  # local tag only, never pushed
+    pull_policy: missing
+    # GPU + large-workload settings (mirrors the bootcamp's docker run flags).
+    privileged: true
+    ipc: host
+    ulimits:
+      memlock: -1
+      stack: 67108864
+    shm_size: 1g
+    ports:
+      - "8888:8888"  # JupyterLab
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped

--- a/brev/dockerfile
+++ b/brev/dockerfile
@@ -1,0 +1,46 @@
+# Copyright (c) 2025 NVIDIA Corporation.  All rights reserved.
+#
+# Brev launchable image for the "End-to-End AI for Science" bootcamp.
+# This builds *on top of* the official NVIDIA PhysicsNeMo container and
+# installs the additional Python/system dependencies the notebooks need.
+# Nothing is pushed to a registry - Brev builds this locally on the instance
+# from the PhysicsNeMo base image via docker compose.
+#
+# Base image: https://catalog.ngc.nvidia.com/orgs/nvidia/teams/physicsnemo/containers/physicsnemo
+
+FROM nvcr.io/nvidia/physicsnemo/physicsnemo:26.05
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    SHELL=/bin/bash \
+    PIP_ROOT_USER_ACTION=ignore \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# System dependencies:
+#   ffmpeg            - rendering animations / videos in the notebooks
+#   git               - pip installs from git, notebook clones
+#   libgl1/libegl1/.. - headless rendering for cartopy / matplotlib / pyvista
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    git \
+    libgl1 \
+    libglx-mesa0 \
+    libegl1 \
+ && apt-get clean -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements first for better Docker layer caching.
+COPY brev/requirements.txt /opt/requirements.txt
+RUN pip install --no-cache-dir -r /opt/requirements.txt \
+ && rm -f /opt/requirements.txt \
+ && jupyter labextension disable "@jupyterlab/apputils-extension:announcements" || true
+
+# Copy the bootcamp materials into the image.
+COPY workspace/ /workspace/
+
+WORKDIR /workspace/python
+EXPOSE 8888
+
+COPY brev/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/brev/entrypoint.sh
+++ b/brev/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 NVIDIA Corporation.  All rights reserved.
+#
+# Entrypoint for the Brev launchable: starts JupyterLab serving the bootcamp
+# notebooks. Brev forwards port 8888 to the user.
+
+set -euo pipefail
+
+echo "Starting JupyterLab on 0.0.0.0:8888 ..."
+exec jupyter lab \
+    --ip=0.0.0.0 \
+    --port=8888 \
+    --allow-root \
+    --no-browser \
+    --ServerApp.token="${JUPYTER_TOKEN:-}" \
+    --ServerApp.password="" \
+    --notebook-dir=/workspace/python

--- a/brev/requirements.txt
+++ b/brev/requirements.txt
@@ -1,0 +1,20 @@
+# Extra Python dependencies for the End-to-End AI for Science bootcamp,
+# installed on top of the NVIDIA PhysicsNeMo 26.05 base image.
+
+# --- Jupyter ---
+jupyterlab
+jupyterlab-widgets
+ipywidgets
+ipympl
+jupyter-resource-usage
+jupyter-archive
+nbconvert
+
+# --- Earth-2 / weather (Module 3 + GTC workshops) ---
+earth2studio==0.14.0
+
+# --- Scientific / plotting / data access ---
+cartopy
+mlflow
+gdown
+cdsapi


### PR DESCRIPTION
## What

Adds a `brev/` folder that defines a [Brev](https://developer.nvidia.com/brev) launchable for this bootcamp. It builds **on top of the official [PhysicsNeMo 26.05](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/physicsnemo/containers/physicsnemo?version=26.05) container** and installs the additional dependencies via Docker Compose, then serves the notebooks in JupyterLab on port `8888`.

Modeled on the [`accelerated-computing-hub` brev folder](https://github.com/NVIDIA/accelerated-computing-hub/tree/main/tutorials/cuda-tile/brev) pattern (compose + dockerfile + requirements).

### Files (`brev/`)
| File | Purpose |
| --- | --- |
| `docker-compose.yml` | Brev entrypoint — builds the image locally, reserves all GPUs, exposes JupyterLab on `8888`. |
| `dockerfile` | `FROM nvcr.io/nvidia/physicsnemo/physicsnemo:26.05` + system/Python deps, copies `workspace/`. |
| `requirements.txt` | JupyterLab, `earth2studio==0.14.0`, cartopy, mlflow, gdown, cdsapi, etc. |
| `entrypoint.sh` | Launches JupyterLab serving `/workspace/python`. |
| `README.md` | Local + Brev usage instructions. |

## Why

Gives users a one-click cloud GPU path to run the bootcamp without building the existing root `Dockerfile` locally, on a current PhysicsNeMo base.

## Notes for reviewers

- **No image is published.** The launchable builds from the PhysicsNeMo base on the instance via `docker compose` — nothing is pushed to or pulled from a private registry. The PhysicsNeMo 26.05 base is pullable anonymously from `nvcr.io`.
- **Datasets are fetched on demand** rather than baked into the image (unlike the root `Dockerfile`'s `dataset.py` step), to keep the image small and avoid flaky Google Drive downloads during the build.
- Scope is a **core launcher** (PhysicsNeMo + JupyterLab + Earth2Studio + common scientific deps). Module-specific extras (DoMINO/Transolver/MagnetoHydrodynamics) can be installed from their own `requirements.txt` inside a running notebook.
- `earth2studio` is pinned to `0.14.0` to match the in-repo GTC Earth-2 workshops.

## Validation

Smoke-tested on a Brev L4 instance: `docker compose -f brev/docker-compose.yml up --build` pulls the PhysicsNeMo 26.05 base, installs deps, and starts JupyterLab on `8888`. (Build/serve result appended as a comment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
